### PR TITLE
Fix capitalization in C include statements

### DIFF
--- a/LogAndStream/shimmer3_common_source/5xx_HAL/hal_Board.c
+++ b/LogAndStream/shimmer3_common_source/5xx_HAL/hal_Board.c
@@ -36,7 +36,7 @@
  ******************************************************************************/
 
 #include "msp430.h"
-#include "HAL_Board.h"
+#include "hal_Board.h"
 
 #define XT1_PORT_DIR             P7DIR
 #define XT1_PORT_OUT             P7OUT

--- a/LogAndStream/shimmer3_common_source/5xx_HAL/hal_Button.c
+++ b/LogAndStream/shimmer3_common_source/5xx_HAL/hal_Button.c
@@ -38,7 +38,7 @@
  ******************************************************************************/
 
 #include "msp430.h"
-#include "HAL_Button.h"
+#include "hal_Button.h"
 #include "../msp430_clock/msp430_clock.h"
 
 

--- a/LogAndStream/shimmer3_common_source/Bluetooth_SD/RN42.c
+++ b/LogAndStream/shimmer3_common_source/Bluetooth_SD/RN42.c
@@ -1,6 +1,6 @@
 #include "msp430.h"
 #include "RN42.h"
-#include "../5XX_hal/hal_DMA.h"
+#include "../5xx_HAL/hal_DMA.h"
 #include <string.h>
 #include <ctype.h>
 #include <stdio.h>

--- a/LogAndStream/shimmer3_common_source/EXG/ads1292.c
+++ b/LogAndStream/shimmer3_common_source/EXG/ads1292.c
@@ -43,7 +43,7 @@
 #include "ads1292.h"
 #include "msp430.h"
 #include <string.h>
-#include "../5XX_hal/hal_UCA0.h"
+#include "../5xx_HAL/hal_UCA0.h"
 
 //uint8_t exgOrUart;
 

--- a/S3_Sleep/shimmer3_common_source/Bluetooth_SD/RN42.c
+++ b/S3_Sleep/shimmer3_common_source/Bluetooth_SD/RN42.c
@@ -1,6 +1,6 @@
 #include "msp430.h"
 #include "RN42.h"
-#include "../5XX_hal/hal_DMA.h"
+#include "../5XX_HAL/hal_DMA.h"
 #include <string.h>
 #include <ctype.h>
 #include <stdio.h>

--- a/S3_Sleep/shimmer3_common_source/EXG/ads1292.c
+++ b/S3_Sleep/shimmer3_common_source/EXG/ads1292.c
@@ -43,7 +43,7 @@
 #include "ads1292.h"
 #include "msp430.h"
 #include <string.h>
-#include "../5XX_hal/hal_UCA0.h"
+#include "../5XX_HAL/hal_UCA0.h"
 
 //uint8_t exgOrUart;
 

--- a/SDLog/Bluetooth_SD/RN42.c
+++ b/SDLog/Bluetooth_SD/RN42.c
@@ -1,6 +1,6 @@
 #include "msp430.h"
 #include "RN42.h"
-#include "../5XX_hal/hal_DMA.h"
+#include "../5XX_HAL/hal_DMA.h"
 #include <string.h>
 #include <ctype.h>
 #include <stdio.h>

--- a/SDLog/EXG/ads1292.c
+++ b/SDLog/EXG/ads1292.c
@@ -43,7 +43,7 @@
 #include "ads1292.h"
 #include "msp430.h"
 #include <string.h>
-#include "../5XX_hal/hal_UCA0.h"
+#include "../5XX_HAL/hal_UCA0.h"
 
 //uint8_t exgOrUart;
 


### PR DESCRIPTION
I work with the Shimmer firmware on Linux where the filesystem is case sensitive. This leads to several errors when building the project because some include statements are not correctly capitalized. The following pull request fixes all include statements that would otherwise prevent the build.