### PR TITLE
Fix uninitialized variable usage for UART GET Infomem Request

### DIFF
--- a/LogAndStream/main.c
+++ b/LogAndStream/main.c
@@ -8523,7 +8523,7 @@ void UartSendRsp()
         *(uartRespBuf + uart_resp_len++) = uartInfoMemLength + 2;
         *(uartRespBuf + uart_resp_len++) = UART_COMP_SHIMMER;
         *(uartRespBuf + uart_resp_len++) = UART_PROP_INFOMEM;
-        if ((uartDcMemLength + uart_resp_len) < UART_RSP_PACKET_SIZE)
+        if ((uartInfoMemLength + uart_resp_len) < UART_RSP_PACKET_SIZE)
         {
             InfoMem_read((void*) uartInfoMemOffset, uartRespBuf + uart_resp_len,
                          uartInfoMemLength);

--- a/SDLog/main.c
+++ b/SDLog/main.c
@@ -3570,7 +3570,7 @@ void UartSendRsp()
         *(uartRespBuf + uart_resp_len++) = uartInfoMemLength + 2;
         *(uartRespBuf + uart_resp_len++) = UART_COMP_SHIMMER;
         *(uartRespBuf + uart_resp_len++) = UART_PROP_INFOMEM;
-        if ((uartDcMemLength + uart_resp_len) < UART_RSP_PACKET_SIZE)
+        if ((uartInfoMemLength + uart_resp_len) < UART_RSP_PACKET_SIZE)
         {
             InfoMem_read((void*) uartInfoMemOffset, uartRespBuf + uart_resp_len,
                          uartInfoMemLength);


### PR DESCRIPTION
Pull request for issue #8 

Replaces variable `uartDcMemLength` with `uartInfoMemLength` in respective if clauses.