### PR TITLE
Bugfix/race condition

### DIFF
--- a/LogAndStream/main.c
+++ b/LogAndStream/main.c
@@ -4404,7 +4404,7 @@ void SendResponse(void)
         *(resPacket + packet_length++) = crc_value & 0xFF;
         *(resPacket + packet_length++) = (crc_value & 0xFF00) >> 8;
     }
-    BT_write(resPacket, packet_length);
+    BT_write_busy(resPacket, packet_length);
 }
 
 //void OpenFirstFile(){

--- a/LogAndStream/main.c
+++ b/LogAndStream/main.c
@@ -4404,7 +4404,7 @@ void SendResponse(void)
         *(resPacket + packet_length++) = crc_value & 0xFF;
         *(resPacket + packet_length++) = (crc_value & 0xFF00) >> 8;
     }
-    BT_write_busy(resPacket, packet_length);
+    BT_write(resPacket, packet_length);
 }
 
 //void OpenFirstFile(){

--- a/LogAndStream/main.c
+++ b/LogAndStream/main.c
@@ -4404,7 +4404,7 @@ void SendResponse(void)
         *(resPacket + packet_length++) = crc_value & 0xFF;
         *(resPacket + packet_length++) = (crc_value & 0xFF00) >> 8;
     }
-    BT_write(resPacket, packet_length);
+    BT_append(resPacket, packet_length);
 }
 
 //void OpenFirstFile(){

--- a/LogAndStream/shimmer3_common_source/Bluetooth_SD/RN42.c
+++ b/LogAndStream/shimmer3_common_source/Bluetooth_SD/RN42.c
@@ -742,6 +742,12 @@ void BT_disable()
     starting = 0;
 }
 
+uint8_t BT_write_busy(uint8_t *buf, uint8_t len)
+{
+    while (BT_write(buf, len) == 0);
+    return 1;
+}
+
 //write data to be transmitted to the Bluetooth module
 //returns 0 if fails, else 1
 //will only fail if a previous BT_write is still in progress

--- a/LogAndStream/shimmer3_common_source/Bluetooth_SD/RN42.c
+++ b/LogAndStream/shimmer3_common_source/Bluetooth_SD/RN42.c
@@ -780,11 +780,12 @@ uint8_t BT_append(uint8_t *buf, uint8_t len)
 {
     if (messageInProgress)
     {
-        if (len + messageLength <= 135)
-            messageLength += len;
-        else
+        if (len + messageLength > 135)
             return 0;
-        memcpy(messageBuffer + charsSent, buf, len);
+
+        memcpy(messageBuffer + messageLength, buf, len);
+        messageLength += len;
+        return 1;
     }
     else
     {

--- a/LogAndStream/shimmer3_common_source/Bluetooth_SD/RN42.c
+++ b/LogAndStream/shimmer3_common_source/Bluetooth_SD/RN42.c
@@ -742,12 +742,6 @@ void BT_disable()
     starting = 0;
 }
 
-uint8_t BT_write_busy(uint8_t *buf, uint8_t len)
-{
-    while (BT_write(buf, len) == 0);
-    return 1;
-}
-
 //write data to be transmitted to the Bluetooth module
 //returns 0 if fails, else 1
 //will only fail if a previous BT_write is still in progress

--- a/LogAndStream/shimmer3_common_source/Bluetooth_SD/RN42.h
+++ b/LogAndStream/shimmer3_common_source/Bluetooth_SD/RN42.h
@@ -34,6 +34,7 @@ extern void BT_startDone_cb(void (*cb)(void));
 //returns 0 if fails, else 1
 //will only fail if a previous BT_write is still in progress
 extern uint8_t BT_write(uint8_t *buf, uint8_t len);
+extern uint8_t BT_write_busy(uint8_t *buf, uint8_t len);
 
 extern uint8_t BT_append(uint8_t *buf, uint8_t len);
 //connect to a specific device that was previously discovered

--- a/LogAndStream/shimmer3_common_source/Bluetooth_SD/RN42.h
+++ b/LogAndStream/shimmer3_common_source/Bluetooth_SD/RN42.h
@@ -34,7 +34,6 @@ extern void BT_startDone_cb(void (*cb)(void));
 //returns 0 if fails, else 1
 //will only fail if a previous BT_write is still in progress
 extern uint8_t BT_write(uint8_t *buf, uint8_t len);
-extern uint8_t BT_write_busy(uint8_t *buf, uint8_t len);
 
 extern uint8_t BT_append(uint8_t *buf, uint8_t len);
 //connect to a specific device that was previously discovered


### PR DESCRIPTION
This is an attempt to fix the race condition in the Bluetooth Stack mentioned in Issue #7. It contains the following changes to the source code:

`SendResponse` in [main.c](https://github.com/ShimmerResearch/shimmer3/blob/04d8e21e21c4be8b58596cfc57d9eb5f5f7d68c5/LogAndStream/main.c#L4407) now uses BT_append instead of BT_write. This ensures that the acknowledgment byte is appended to the send buffer instead of being dropped due to a pending write operation.

In the `BT_append` function in [RN42.c](https://github.com/ShimmerResearch/shimmer3/blob/04d8e21e21c4be8b58596cfc57d9eb5f5f7d68c5/S3_Sleep/shimmer3_common_source/Bluetooth_SD/RN42.c#L779) the if clause for handling the actual append operation if `messageInProgress` is `true` is updated. The pointer arithmetic is fixed such that the new data is copied to the correct location. Additionally, the function now exits early with `return 1` to ensure that `sendNextChar` is not called again. This would increment the `charsSent` counter and thereby drop a single byte from the send buffer.

This commit fixes the described error on my end. I would greatly appreciate feedback on whether this fix also performs as intended in your test environment.