### PR TITLE
DEV-731 pull-ups enabled on CHRG STAT pins

### DIFF
--- a/LogAndStream_Shimmer3/Shimmer_Driver/5xx_HAL/hal_Board.c
+++ b/LogAndStream_Shimmer3/Shimmer_Driver/5xx_HAL/hal_Board.c
@@ -136,8 +136,8 @@ void Board_init(void)
   P1DIR &= ~BIT7;
 
   //Analog Accel
-  P8OUT &= ~BIT6;
-  P8REN |= BIT6;  //enable pull up resistor
+  P8OUT &= ~BIT6; //select pull-down when resistor is enabled
+  P8REN |= BIT6;  //enable pull resistor
   P8DIR &= ~BIT6; //SW_ACCEL set as input
 
   P6DIR &= ~(BIT3 + BIT4 + BIT5); //ACCEL_X/Y/Z input

--- a/LogAndStream_Shimmer3/Shimmer_Driver/5xx_HAL/hal_Board.c
+++ b/LogAndStream_Shimmer3/Shimmer_Driver/5xx_HAL/hal_Board.c
@@ -97,6 +97,7 @@ void Board_init(void)
   P3DIR |= BIT6;  //set as output
 
   //Make the 2 CHG_STAT pins input
+  P2REN |= (BIT6 + BIT7); //pull-up resistor (external pull is too weak at 698k)
   P2DIR &= ~(BIT6 + BIT7);
 
   //Battery voltage ADC pin as input
@@ -135,7 +136,7 @@ void Board_init(void)
 
   //Analog Accel
   P8OUT &= ~BIT6;
-  P8REN |= BIT6;  //enable pull down resistor
+  P8REN |= BIT6;  //enable pull up resistor
   P8DIR &= ~BIT6; //SW_ACCEL set as input
 
   P6DIR &= ~(BIT3 + BIT4 + BIT5); //ACCEL_X/Y/Z input

--- a/LogAndStream_Shimmer3/Shimmer_Driver/5xx_HAL/hal_Board.c
+++ b/LogAndStream_Shimmer3/Shimmer_Driver/5xx_HAL/hal_Board.c
@@ -97,6 +97,7 @@ void Board_init(void)
   P3DIR |= BIT6;  //set as output
 
   //Make the 2 CHG_STAT pins input
+  P2OUT |= (BIT6 + BIT7); //select pull-up when resistor is enabled
   P2REN |= (BIT6 + BIT7); //pull-up resistor (external pull is too weak at 698k)
   P2DIR &= ~(BIT6 + BIT7);
 


### PR DESCRIPTION
This pull request makes minor adjustments to the hardware initialization code in `hal_Board.c` to improve pin configuration for input and pull-up resistors. The changes focus on ensuring proper input detection and signal reliability for specific pins.

Pin configuration improvements:

* Added pull-up resistors to `P2.6` and `P2.7` for the two `CHG_STAT` pins to improve input reliability, as the external pull is too weak.
* Changed the pull resistor for the analog accelerometer (`P8.6`) from pull-down to pull-up to better match the intended input behavior.