### PR TITLE
DEV-759 Workaround for GSR spikes while ADC sensing

### DIFF
--- a/LogAndStream_Shimmer3/adc.c
+++ b/LogAndStream_Shimmer3/adc.c
@@ -319,14 +319,30 @@ void SetBattDma(void)
 
 void manageReadBatt(uint8_t isBlockingRead)
 {
-  SetBattDma();
-  //Produces spikes in PPG data when only GSR enabled & aaccel, vbatt are off.
-  __bis_SR_register(LPM3_bits + GIE); //ACLK remains active
-
-  //TODO check if this is really needed
-  ShimSens_configureChannels();
-
-  saveBatteryVoltageAndUpdateStatus();
+  /* ADC sensor data is prioritised over an up-to-date battery value - only take a
+   * fresh measurement (which borrows the shared ADC12/DMA0) when it cannot disturb
+   * the ADC sensor stream. See LogAndStream_getBattReadAction(). */
+  switch (LogAndStream_getBattReadAction())
+  {
+    case BATT_READ_USE_STREAM:
+      //Use the VBatt sample from the last completed sensing buffer (not the
+      //write index, which the DMA may be filling).
+      *(uint16_t *) battVal
+          = *(uint16_t *) &ShimSens_getDataBuffAtPrevWrIdx()[sensing.ptr.batteryAnalog];
+      saveBatteryVoltageAndUpdateStatus();
+      break;
+    case BATT_READ_REPEAT_LAST:
+      /* Another ADC channel is being sensed on the shared ADC. A read would
+       * disturb the sensor data, so keep the last measured value. */
+      break;
+    case BATT_READ_NEW:
+    default:
+      SetBattDma();
+      __bis_SR_register(LPM3_bits + GIE); //ACLK remains active
+      ShimSens_configureChannels();
+      saveBatteryVoltageAndUpdateStatus();
+      break;
+  }
 }
 
 void saveBatteryVoltageAndUpdateStatus(void)

--- a/LogAndStream_Shimmer3/adc.c
+++ b/LogAndStream_Shimmer3/adc.c
@@ -319,9 +319,9 @@ void SetBattDma(void)
 
 void manageReadBatt(uint8_t isBlockingRead)
 {
-  /* ADC sensor data is prioritised over an up-to-date battery value - only take a
-   * fresh measurement (which borrows the shared ADC12/DMA0) when it cannot disturb
-   * the ADC sensor stream. See LogAndStream_getBattReadAction(). */
+  /* ADC sensor data is prioritised over an up-to-date battery value - only take
+   * a fresh measurement (which borrows the shared ADC12/DMA0) when it cannot
+   * disturb the ADC sensor stream. See LogAndStream_getBattReadAction(). */
   switch (LogAndStream_getBattReadAction())
   {
     case BATT_READ_USE_STREAM:

--- a/LogAndStream_Shimmer3/adc.c
+++ b/LogAndStream_Shimmer3/adc.c
@@ -319,6 +319,10 @@ void SetBattDma(void)
 
 void manageReadBatt(uint8_t isBlockingRead)
 {
+  //Shimmer3 reads the battery synchronously; the blocking-read hint is unused here
+  //(the shared signature is kept for Shimmer3R, which passes it to S4_ADC_readBatt).
+  (void) isBlockingRead;
+
   /* ADC sensor data is prioritised over an up-to-date battery value - only take
    * a fresh measurement (which borrows the shared ADC12/DMA0) when it cannot
    * disturb the ADC sensor stream. See LogAndStream_getBattReadAction(). */

--- a/LogAndStream_Shimmer3/main.c
+++ b/LogAndStream_Shimmer3/main.c
@@ -738,7 +738,10 @@ uint8_t checkIfBattReadNeeded(void)
   if ((batt_td > ShimBatt_getBatteryIntervalTicks()))
   {
     battLastTs64 = batt_my_local_time_64;
-    if (!shimmerStatus.sensing && ShimTask_set(TASK_BATT_READ))
+    /* Read the battery periodically even while sensing - manageReadBatt() applies
+     * the ADC-priority policy (LogAndStream_getBattReadAction), so the read never
+     * disturbs the ADC sensor stream. */
+    if (ShimTask_set(TASK_BATT_READ))
     {
       return 1;
     }

--- a/LogAndStream_Shimmer3/main.c
+++ b/LogAndStream_Shimmer3/main.c
@@ -738,9 +738,9 @@ uint8_t checkIfBattReadNeeded(void)
   if ((batt_td > ShimBatt_getBatteryIntervalTicks()))
   {
     battLastTs64 = batt_my_local_time_64;
-    /* Read the battery periodically even while sensing - manageReadBatt() applies
-     * the ADC-priority policy (LogAndStream_getBattReadAction), so the read never
-     * disturbs the ADC sensor stream. */
+    /* Read the battery periodically even while sensing - manageReadBatt()
+     * applies the ADC-priority policy (LogAndStream_getBattReadAction), so the
+     * read never disturbs the ADC sensor stream. */
     if (ShimTask_set(TASK_BATT_READ))
     {
       return 1;


### PR DESCRIPTION
This pull request updates the battery voltage reading logic to prioritize uninterrupted ADC sensor data streaming, ensuring battery measurements do not interfere with sensor data collection. It also updates a submodule to a newer commit.

Improvements to battery voltage reading logic:

* The `manageReadBatt` function in `adc.c` now uses a policy (via `LogAndStream_getBattReadAction()`) to determine when it is safe to take a fresh battery measurement, preventing disturbance to ongoing ADC sensor streams. It uses the last available battery value or repeats the last measurement if a new read would interfere.
* The periodic battery read trigger in `main.c` is now allowed even during sensor streaming, relying on the new ADC-priority policy to avoid interference.

Dependency updates:

* The `log-and-stream-common` submodule is updated to a newer commit, which may include bug fixes or new features.