### PR TITLE
DEV-833 Print firmware version in factory test report; include-safe version.h

### DIFF
--- a/LogAndStream_Shimmer3/Shimmer_Driver/version.h
+++ b/LogAndStream_Shimmer3/Shimmer_Driver/version.h
@@ -16,7 +16,9 @@ typedef struct
   uint8_t patch;
 } firmware_version_t;
 
-__attribute__((section(".version"), used)) static const firmware_version_t fw_version_struct
-    = { .major = FW_VERSION_MAJOR, .minor = FW_VERSION_MINOR, .patch = FW_VERSION_PATCH };
+/* The definition lives in each firmware's main.c so this header can be included
+ * by multiple translation units without emitting a duplicate object into the
+ * .version linker section. */
+extern const firmware_version_t fw_version_struct;
 
 #endif //VERSION_H

--- a/LogAndStream_Shimmer3/lnk_msp430f5437a.cmd
+++ b/LogAndStream_Shimmer3/lnk_msp430f5437a.cmd
@@ -133,6 +133,11 @@ MEMORY
 /* SPECIFY THE SECTIONS ALLOCATION INTO MEMORY                              */
 /****************************************************************************/
 
+/* Retain the firmware version marker: TI --unused_section_elimination        */
+/* otherwise drops .version because nothing references fw_version_struct       */
+/* (the GNU-linker targets keep it via KEEP() in their linker scripts).        */
+--retain="*(.version)"
+
 SECTIONS
 {
     .bss        : {} > RAM                /* GLOBAL & STATIC VARS              */

--- a/LogAndStream_Shimmer3/lnk_msp430f5437a.cmd
+++ b/LogAndStream_Shimmer3/lnk_msp430f5437a.cmd
@@ -144,6 +144,7 @@ SECTIONS
     .text:_isr  : {} > FLASH              /* ISR CODE SPACE                    */
     .cinit      : {} > FLASH | FLASH2     /* INITIALIZATION TABLES             */
     .const      : {} > FLASH | FLASH2     /* CONSTANT DATA                     */
+    .version    : {} > FLASH              /* FW VERSION TRACEABILITY MARKER    */
     .cio        : {} > RAM                /* C I/O BUFFER                      */
 
     .pinit      : {} > FLASH              /* C++ CONSTRUCTOR TABLES            */

--- a/LogAndStream_Shimmer3/main.c
+++ b/LogAndStream_Shimmer3/main.c
@@ -79,6 +79,13 @@
 #include "shimmer_driver_include.h"
 #include "version.h"
 
+/* Firmware version marker embedded in the .version linker section for
+ * traceability. Defined here (rather than in the auto-generated version.h) so
+ * version.h can be included by multiple translation units without duplicating
+ * this object across the .version section. */
+__attribute__((section(".version"), used)) const firmware_version_t fw_version_struct
+    = { .major = FW_VERSION_MAJOR, .minor = FW_VERSION_MINOR, .patch = FW_VERSION_PATCH };
+
 void Init(void);
 void InitialiseBt(void);
 void InitialiseBtAfterBoot(void);


### PR DESCRIPTION
## Summary

Brings the Shimmer3 factory test report in line with DEV-832 (Verisense): it now prints the firmware version, and `version.h` is made include-safe.

Jira: [DEV-833](https://shimmersensing.atlassian.net/browse/DEV-833)

- Bumps **`log-and-stream-common`** to the shared branch that adds `Firmware version: <FW_VERSION_STRING>` to the report.
- **`Shimmer_Driver/version.h`** — `fw_version_struct` is now `extern`; the single definition lives in `main.c`. Stops the `.version` object being duplicated across every TU that includes `version.h`.
- **`lnk_msp430f5437a.cmd`** — explicit `.version` output-section placement (the section already exists in the build; this makes its placement defined).

## ⚠️ Not build-verified

The MSP430 / TI (CCS) toolchain isn't available in this environment, so this hasn't been compiled. Please build in CCS and confirm:

- It links.
- `.version` is retained in the image — if TI's unused-section elimination drops it, add `--retain`/a `RETAIN()` for `.version`.

The **equivalent change is verified** on the Shimmer3R STM32 build (see [DEV-834](https://shimmersensing.atlassian.net/browse/DEV-834)) — the only Shimmer3-specific piece is the MSP430 linker placement.

## Note

Depends on the common-repo PR — the submodule currently points at that branch's commit. After the common PR merges, re-point the submodule to the merged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DEV-833]: https://shimmersensing.atlassian.net/browse/DEV-833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-834]: https://shimmersensing.atlassian.net/browse/DEV-834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ